### PR TITLE
Update docs to point to the latest Tensorflow version in osx

### DIFF
--- a/docs/guide/install_software.md
+++ b/docs/guide/install_software.md
@@ -259,7 +259,7 @@ source activate donkey
 * Install Tensorflow
 
 ```
-pip install https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.3.0-py3-none-any.whl
+pip install https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.10.1-py3-none-any.whl
 ```
 
 


### PR DESCRIPTION
Docs point to Tensorflow version 1.3 which doesn't contain the module 'tensorflow.python.keras' which is imported in '/donkeycar/parts/keras.py'